### PR TITLE
refactor: move methods iterating over keywords to single analyze

### DIFF
--- a/analyze.js
+++ b/analyze.js
@@ -1,0 +1,32 @@
+import keywords from './keywords';
+import { LanguageDetector } from './utils';
+
+export const analyze = (text) => {
+  let matchedKeywords = [];
+  let relevanceScore = 0;
+
+  const language = LanguageDetector.detect(text);
+  const relevantKeywords = keywords[language] || keywords.en;
+
+  relevantKeywords.forEach((keyword) => {
+    // Escape special characters and create pattern
+    const escapedKeyword = keyword.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(`\\b${escapedKeyword}\\b`, 'i');
+
+    // Score based on keyword matches with word boundaries
+    const lowerText = text.toLowerCase();
+    const matches = (lowerText.match(pattern) || []).length;
+    relevanceScore += matches;
+
+    // Get matched keywords for debugging
+    if (matches > 0) {
+      matchedKeywords.push(keyword);
+    }
+  });
+
+  return {
+    isRelevant: relevanceScore > 0,
+    matchedKeywords,
+    relevanceScore,
+  };
+};

--- a/analyze.test.js
+++ b/analyze.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { analyze } from './analyze';
+
+describe('analyze', () => {
+  describe('WHEN the text is relevant', () => {
+    const relevantText =
+      'This text contains the following relevant keywords: aroace, acespec, aromantic.';
+
+    it('SHOULD identify relevant content', () => {
+      const { isRelevant } = analyze(relevantText);
+      expect(isRelevant).toBe(true);
+    });
+
+    it('SHOULD get matched keywords AND calculate relevance score', () => {
+      const { matchedKeywords } = analyze(relevantText);
+      expect(matchedKeywords).toEqual(expect.arrayContaining(['aroace', 'acespec', 'aromantic']));
+    });
+
+    it('SHOULD calculate relevance score', () => {
+      const { relevanceScore } = analyze(relevantText);
+      expect(relevanceScore).toBe(3);
+    });
+  });
+  describe('WHEN the text is NOT relevant', () => {
+    const nonRelevantText = 'This is a text containing non relevant content';
+
+    it('SHOULD NOT identify relevant content', () => {
+      const { isRelevant } = analyze(nonRelevantText);
+      expect(isRelevant).toBe(false);
+    });
+
+    it('SHOULD NOT get matched keywords', () => {
+      const { matchedKeywords } = analyze(nonRelevantText);
+      expect(matchedKeywords.length).toBe(0);
+    });
+
+    it('SHOULD return a relevance score of 0', () => {
+      const { relevanceScore } = analyze(nonRelevantText);
+      expect(relevanceScore).toBe(0);
+    });
+  });
+});

--- a/analyze.test.js
+++ b/analyze.test.js
@@ -11,7 +11,7 @@ describe('analyze', () => {
       expect(isRelevant).toBe(true);
     });
 
-    it('SHOULD get matched keywords AND calculate relevance score', () => {
+    it('SHOULD get matched keywords', () => {
       const { matchedKeywords } = analyze(relevantText);
       expect(matchedKeywords).toEqual(expect.arrayContaining(['aroace', 'acespec', 'aromantic']));
     });

--- a/filters.js
+++ b/filters.js
@@ -1,65 +1,46 @@
 import nlp from 'compromise';
-import { keywords } from './keywords.js';
-import { LanguageDetector } from './utils.js';
 
 export const aceFilters = {
-  // Check if post contains ace/aro related content
-  isAceAroContent: (text) => {
-    const language = LanguageDetector.detect(text);
-    const lowerText = text.toLowerCase();
-    
-    // Check for ace/aro keywords with word boundaries
-    const relevantKeywords = keywords[language] || keywords.en;
-    return relevantKeywords.some(keyword => {
-      // Escape special characters and create pattern
-      const escapedKeyword = keyword.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      const pattern = new RegExp(`\\b${escapedKeyword}\\b`, 'i');
-      return pattern.test(lowerText);
-    });
-  },
-
   // Filter out potentially inappropriate or off-topic content
   isAppropriate: (text) => {
     const doc = nlp(text);
-    
+
     // Check for explicit content markers
     const hasExplicitContent = doc.match('#Explicit').found;
     if (hasExplicitContent) return false;
-    
+
     // Check for spam patterns
-    const isSpam = doc.match('#Spam').found ||
-      text.match(/\b(buy|sell|discount|offer)\b/gi)?.length > 2;
+    const isSpam =
+      doc.match('#Spam').found || text.match(/\b(buy|sell|discount|offer)\b/gi)?.length > 2;
     if (isSpam) return false;
-    
+
     return true;
   },
-
-  // Calculate relevance score for sorting
-  getRelevanceScore: (text) => {
-    const language = LanguageDetector.detect(text);
-    const lowerText = text.toLowerCase();
-    const relevantKeywords = keywords[language] || keywords.en;
-    let score = 0;
-    
-    // Score based on keyword matches with word boundaries
-    relevantKeywords.forEach(keyword => {
-      const escapedKeyword = keyword.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      const pattern = new RegExp(`\\b${escapedKeyword}\\b`, 'gi');
-      const matches = (text.match(pattern) || []).length;
-      score += matches;
-    });
-    
-    return score;
-  }
 };
 
 export const sentimentConfig = {
   positive: [
-    'pride', 'happy', 'valid', 'acceptance', 'community',
-    'support', 'love', 'understanding', 'authentic', 'belonging'
+    'pride',
+    'happy',
+    'valid',
+    'acceptance',
+    'community',
+    'support',
+    'love',
+    'understanding',
+    'authentic',
+    'belonging',
   ],
   negative: [
-    'hate', 'invalid', 'broken', 'wrong', 'sick',
-    'unnatural', 'confused', 'phase', 'lonely', 'reject'
-  ]
+    'hate',
+    'invalid',
+    'broken',
+    'wrong',
+    'sick',
+    'unnatural',
+    'confused',
+    'phase',
+    'lonely',
+    'reject',
+  ],
 };


### PR DESCRIPTION
Hi Ignacio!
This is a proposal for refactor. I moved the three methods that iterate over keywords to a single iteration analyze() to reduce duplication and improve performance (not really needed at this point, but nice to have). I also added some basic tests to this new function.
There are some irrelevant changes coming from prettier, sorry about that! I didn't know how to disable it.
I hope this helps!