### PR TITLE
Fix code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/server.js
+++ b/server.js
@@ -21,12 +21,7 @@ const debugAuth = (req, res, next) => {
   const decoded = Buffer.from(encoded, 'base64').toString('utf-8');
   const [username, password] = decoded.split(':');
 
-  console.log('Debug Auth:', {
-    expectedUsername: process.env.DEBUG_USERNAME,
-    expectedPassword: process.env.DEBUG_PASSWORD,
-    receivedUsername: username,
-    receivedPassword: password,
-  });
+  console.log('Debug Auth: Authentication attempt received');
 
   // Check credentials against environment variables
   if (username === process.env.DEBUG_USERNAME && password === process.env.DEBUG_PASSWORD) {


### PR DESCRIPTION
Fixes [https://github.com/imigueldiaz/bluesky-aroace-feed/security/code-scanning/1](https://github.com/imigueldiaz/bluesky-aroace-feed/security/code-scanning/1)

To fix the problem, we should avoid logging sensitive information such as usernames and passwords. Instead, we can log non-sensitive information that can still be useful for debugging purposes. For example, we can log whether the authentication was successful or not without including the actual credentials.

- Remove the `console.log` statement that logs sensitive information.
- Replace it with a log statement that indicates whether the authentication attempt was successful or failed, without revealing the actual credentials.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
